### PR TITLE
Changed Path Join 

### DIFF
--- a/example/cmd/README.md
+++ b/example/cmd/README.md
@@ -32,7 +32,7 @@ target to be published immediately.
 $ notary add kolide/greeter/darwin latest/target myfile.tgz -p
 ```
 
-6. Upload the files you added to notary to the mirror. In a production environment this would be something like a public s3 bucket or static file server. 
+6. Upload the files you added to notary to the mirror. In a production environment this would be something like a public s3 bucket or static file server.
 In this example, you just have to add it to the `filerepo/$GUN` folder. The example will server the path on port 8888.
 ```
 ├── README.md
@@ -66,15 +66,15 @@ or manually with curl:
   ```
 8. Define your settings in the example program.
 
-  ``` go
+  ```Go
   settings := updater.Settings{
-    LocalRepoPath:      path.Join(baseDir, "repo"),
-    NotaryURL:          "https://notary-server:4443",
-    StagingPath:        path.Join(baseDir, "staging"),
-    GUN:                "kolide/greeter/darwin",
-    TargetName:         "latest/target",
-    InsecureSkipVerify: true,
-    MirrorURL:          "https://storage.googleapis.com/kolide_test_mirror",
+      LocalRepoPath:      filepath.Join(baseDir, "repo"),
+      NotaryURL:          "https://notary-server:4443",
+      StagingPath:        filepath.Join(baseDir, "staging"),
+      GUN:                "kolide/greeter/darwin",
+      TargetName:         "latest/target",
+      InsecureSkipVerify: true,
+      MirrorURL:          "https://storage.googleapis.com/kolide_test_mirror",
   }
   ```
 9. Run it! Note in this example the repo and staging directory are located relative

--- a/tuf/local_repo.go
+++ b/tuf/local_repo.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -49,7 +49,7 @@ func (r *localRepo) targets(opts ...func() interface{}) (*Targets, error) {
 // data is the class containing the role information
 func (r *localRepo) save(roleName role, data interface{}) error {
 	isRoleCorrect(roleName, data)
-	f, err := os.OpenFile(path.Join(r.repoPath, fmt.Sprintf("%s.json", roleName)), os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(filepath.Join(r.repoPath, fmt.Sprintf("%s.json", roleName)), os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return errors.Wrap(err, "opening role file for writing")
 	}
@@ -62,7 +62,7 @@ func (r *localRepo) getRole(name role, val interface{}) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.Open(path.Join(r.repoPath, fmt.Sprintf("%s.json", name)))
+	f, err := os.Open(filepath.Join(r.repoPath, fmt.Sprintf("%s.json", name)))
 	if err != nil {
 		return errors.Wrap(err, "getting role")
 	}

--- a/tuf/local_repo_test.go
+++ b/tuf/local_repo_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,7 +23,7 @@ func setupLocalTests(t *testing.T) string {
 		func() {
 			buff, err := test.Asset(fmt.Sprintf("test/data/%s.json", r))
 			require.Nil(t, err)
-			f, err := os.OpenFile(path.Join(baseDir, fmt.Sprintf("%s.json", r)), os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(filepath.Join(baseDir, fmt.Sprintf("%s.json", r)), os.O_CREATE|os.O_WRONLY, 0644)
 			require.Nil(t, err)
 			defer f.Close()
 			_, err = io.Copy(f, bytes.NewBuffer(buff))

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -158,8 +157,8 @@ func (rs *repoMan) save(backupTag string) (err error) {
 func (rs *repoMan) backupRoles(tag string) error {
 	roles := []role{roleRoot, roleTargets, roleSnapshot, roleTimestamp}
 	for _, r := range roles {
-		source := path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r))
-		destination := path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
+		source := filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r))
+		destination := filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
 		err := os.Rename(source, destination)
 		if err != nil {
 			return errors.Wrap(err, "backing up role")
@@ -171,8 +170,8 @@ func (rs *repoMan) backupRoles(tag string) error {
 func (rs *repoMan) restoreRoles(tag string) error {
 	roles := []role{roleRoot, roleTargets, roleSnapshot, roleTimestamp}
 	for _, r := range roles {
-		destination := path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r))
-		source := path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
+		destination := filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r))
+		source := filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
 		_, err := os.Stat(source)
 		if os.IsNotExist(err) {
 			continue
@@ -193,7 +192,7 @@ func (rs *repoMan) restoreRoles(tag string) error {
 func (rs *repoMan) deleteBackupRoles(tag string) error {
 	roles := []role{roleRoot, roleTargets, roleSnapshot, roleTimestamp}
 	for _, r := range roles {
-		backupFilePath := path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
+		backupFilePath := filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.%s.json", r, tag))
 		fs, err := os.Stat(backupFilePath)
 		if os.IsNotExist(err) {
 			continue
@@ -212,7 +211,7 @@ func (rs *repoMan) deleteBackupRoles(tag string) error {
 }
 
 func (rs *repoMan) saveRole(r role, js []byte) error {
-	fs, err := os.OpenFile(path.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r)), os.O_CREATE|os.O_WRONLY, 0644)
+	fs, err := os.OpenFile(filepath.Join(rs.settings.LocalRepoPath, fmt.Sprintf("%s.json", r)), os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return errors.Wrap(err, "saving role file")
 	}
@@ -471,7 +470,7 @@ func (rs *repoMan) downloadTarget(client *http.Client, target targetNameType, fi
 		return "", errors.Wrap(err, "target verification failed")
 	}
 	// our target is valid so write it to staging
-	stagingPath := path.Join(rs.settings.StagingPath, string(target))
+	stagingPath := filepath.Join(rs.settings.StagingPath, string(target))
 	// TODO: this needs to tested with Windows
 	// find out if any subdirectories need to be created
 	fullDir := filepath.Dir(stagingPath)

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func createLocalRepo(version int, location string, t *testing.T) {
 		buff, err := test.Asset(source)
 		require.Nil(t, err)
 		func() {
-			target := path.Join(location, fmt.Sprintf("%s.json", role))
+			target := filepath.Join(location, fmt.Sprintf("%s.json", role))
 			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, 0644)
 			require.Nil(t, err)
 			defer f.Close()
@@ -232,10 +233,10 @@ func TestGetStagedPathsWithUpdates(t *testing.T) {
 	require.NotEmpty(t, stagedPath)
 	// make sure all the files we are supposed to create are there
 	files := []string{
-		path.Join(localRepoPath, "root.json"),
-		path.Join(localRepoPath, "timestamp.json"),
-		path.Join(localRepoPath, "snapshot.json"),
-		path.Join(localRepoPath, "targets.json"),
+		filepath.Join(localRepoPath, "root.json"),
+		filepath.Join(localRepoPath, "timestamp.json"),
+		filepath.Join(localRepoPath, "snapshot.json"),
+		filepath.Join(localRepoPath, "targets.json"),
 	}
 
 	for _, f := range files {
@@ -274,10 +275,10 @@ func TestWithRootKeyRotation(t *testing.T) {
 
 	// make sure all the files we are supposed to create are there
 	files := []string{
-		path.Join(localRepoPath, "root.json"),
-		path.Join(localRepoPath, "timestamp.json"),
-		path.Join(localRepoPath, "snapshot.json"),
-		path.Join(localRepoPath, "targets.json"),
+		filepath.Join(localRepoPath, "root.json"),
+		filepath.Join(localRepoPath, "timestamp.json"),
+		filepath.Join(localRepoPath, "snapshot.json"),
+		filepath.Join(localRepoPath, "targets.json"),
 	}
 
 	for _, f := range files {
@@ -303,16 +304,16 @@ func TestBackupAndRecover(t *testing.T) {
 
 	// remove files and make sure that they get restored
 	backupFiles := []string{
-		path.Join(localRepoPath, fmt.Sprintf("root.%s.json", tag)),
-		path.Join(localRepoPath, fmt.Sprintf("timestamp.%s.json", tag)),
-		path.Join(localRepoPath, fmt.Sprintf("snapshot.%s.json", tag)),
-		path.Join(localRepoPath, fmt.Sprintf("targets.%s.json", tag)),
+		filepath.Join(localRepoPath, fmt.Sprintf("root.%s.json", tag)),
+		filepath.Join(localRepoPath, fmt.Sprintf("timestamp.%s.json", tag)),
+		filepath.Join(localRepoPath, fmt.Sprintf("snapshot.%s.json", tag)),
+		filepath.Join(localRepoPath, fmt.Sprintf("targets.%s.json", tag)),
 	}
 	files := []string{
-		path.Join(localRepoPath, "root.json"),
-		path.Join(localRepoPath, "timestamp.json"),
-		path.Join(localRepoPath, "snapshot.json"),
-		path.Join(localRepoPath, "targets.json"),
+		filepath.Join(localRepoPath, "root.json"),
+		filepath.Join(localRepoPath, "timestamp.json"),
+		filepath.Join(localRepoPath, "snapshot.json"),
+		filepath.Join(localRepoPath, "targets.json"),
 	}
 	// backup file should exist, regular file should not
 	for i := range files {
@@ -395,10 +396,10 @@ func TestWithTimestampKeyRotation(t *testing.T) {
 
 	// make sure all the files we are supposed to create are there
 	files := []string{
-		path.Join(localRepoPath, "root.json"),
-		path.Join(localRepoPath, "timestamp.json"),
-		path.Join(localRepoPath, "snapshot.json"),
-		path.Join(localRepoPath, "targets.json"),
+		filepath.Join(localRepoPath, "root.json"),
+		filepath.Join(localRepoPath, "timestamp.json"),
+		filepath.Join(localRepoPath, "snapshot.json"),
+		filepath.Join(localRepoPath, "targets.json"),
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
Closes Issue https://github.com/kolide/updater/issues/11 

Change from using `path.Join` to `filepath.Join` for better cross platform handling of file paths. 