### PR TITLE
Makefile target needs phony.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: deps test
+
 deps:
 	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/jteeuwen/go-bindata/...


### PR DESCRIPTION
The Go tests don't actually run on CI because the target is not aliased.