### PR TITLE
use target instead of timestamp version for validation of 3.3.1

### DIFF
--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -301,13 +301,15 @@ func (rs *repoMan) refreshSnapshot(root *Root, timestamp *Timestamp) (*Snapshot,
 	// if any, MUST be less than or equal to its version number in the new snapshot metadata file.
 	// Furthermore, any targets metadata filename that was listed in the trusted snapshot metadata file,
 	// if any, MUST continue to be listed in the new snapshot metadata file.
-	targets, _, err := rs.refreshTargets(root, current)
+	trustedTargets, err := rs.repo.targets(&localTargetFetcher{rs.repo.baseDir()})
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching target for snapshot validation")
+		return nil, errors.Wrap(err, "fetching trusted targets from snapshot")
 	}
-	if targets.Signed.Version > current.Signed.Version {
+
+	if trustedTargets.Signed.Version > current.Signed.Version {
 		return nil, errRollbackAttack
 	}
+
 	// 3.4. **Check for a freeze attack.** The latest known time should be lower
 	// than the expiration timestamp in this metadata file.
 	if rs.clock.Now().After(current.Signed.Expires) {

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -298,9 +298,10 @@ func (rs *repoMan) refreshSnapshot(root *Root, timestamp *Timestamp) (*Snapshot,
 
 	// 3.3.3. The version number of the targets metadata file, and all delegated
 	// targets metadata files (if any), in the trusted snapshot metadata file,
-	// if any, MUST be less than or equal to its version number in the new snapshot metadata file.
-	// Furthermore, any targets metadata filename that was listed in the trusted snapshot metadata file,
-	// if any, MUST continue to be listed in the new snapshot metadata file.
+	// if any, MUST be less than or equal to its version number in the new snapshot
+	// metadata file. Furthermore, any targets metadata filename that was listed
+	// in the trusted snapshot metadata file, if any, MUST continue to be listed
+	// in the new snapshot metadata file.
 	trustedTargets, err := rs.repo.targets(&localTargetFetcher{rs.repo.baseDir()})
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching trusted targets from snapshot")

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -311,6 +311,12 @@ func (rs *repoMan) refreshSnapshot(root *Root, timestamp *Timestamp) (*Snapshot,
 		return nil, errRollbackAttack
 	}
 
+	for role, target := range trustedTargets.targetLookup {
+		if target.Signed.Version > current.Signed.Version {
+			return nil, errors.Wrapf(errRollbackAttack, "role %s", role)
+		}
+	}
+
 	// 3.4. **Check for a freeze attack.** The latest known time should be lower
 	// than the expiration timestamp in this metadata file.
 	if rs.clock.Now().After(current.Signed.Expires) {

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -295,13 +295,13 @@ func (rs *repoMan) refreshSnapshot(root *Root, timestamp *Timestamp) (*Snapshot,
 	if previous.Signed.Version > current.Signed.Version {
 		return nil, errRollbackAttack
 	}
+
 	// 3.3.3. The version number of the targets metadata file, and all delegated
-	// targets metadata files (if any), in the previous snapshot metadata file, if
-	// any, MUST be less than or equal to its version number in this snapshot
-	// metadata file. Furthermore, any targets metadata filename that was listed
-	// in the previous snapshot metadata file, if any, MUST continue to be listed
-	// in this snapshot metadata file.
-	targets, err := rs.repo.timestamp()
+	// targets metadata files (if any), in the trusted snapshot metadata file,
+	// if any, MUST be less than or equal to its version number in the new snapshot metadata file.
+	// Furthermore, any targets metadata filename that was listed in the trusted snapshot metadata file,
+	// if any, MUST continue to be listed in the new snapshot metadata file.
+	targets, _, err := rs.refreshTargets(root, current)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching target for snapshot validation")
 	}


### PR DESCRIPTION
Using the timestamp doesn't really make sense to compare against snapshot, since the timestamp will increase more frequently. It was likely a copy/paste error in the initial implementation. 

From the spec: 
```
3.3.3. The version number of the targets metadata file, and all delegated targets metadata files (if any), in the trusted snapshot metadata file, if any, MUST be less than or equal to its version number in the new snapshot metadata file. Furthermore, any targets metadata filename that was listed in the trusted snapshot metadata file, if any, MUST continue to be listed in the new snapshot metadata file.
```

This PR now compares the targets metadata file against the snapshot metadata file version. 

