### PR TITLE
Add end to end tests to show correct detection of mis-downloaded files

### DIFF
--- a/tuf/delegation_test.go
+++ b/tuf/delegation_test.go
@@ -49,6 +49,8 @@ func (lr *mockLocalRepoReader) fetch(role string) (*Targets, error) {
 }
 
 func TestMockReader(t *testing.T) {
+	t.Parallel()
+
 	rdr := mockLocalRepoReader{"testdata/delegation/0/"}
 	tt := []struct {
 		path          string
@@ -74,6 +76,8 @@ func TestMockReader(t *testing.T) {
 }
 
 func TestPopulateLocalTargetsWithChildren(t *testing.T) {
+	t.Parallel()
+
 	rdr := mockLocalRepoReader{"testdata/delegation/0/"}
 	root, err := targetTreeBuilder(&rdr)
 	require.NoError(t, err)
@@ -113,6 +117,8 @@ func setupValidationTest(t *testing.T, testRoot string) (*Root, *Snapshot, *Root
 }
 
 func TestTargetReadWithValidations(t *testing.T) {
+	t.Parallel()
+
 	testRootPath := "testdata/delegation/0"
 	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testDataPath := strings.Replace(strings.Replace(r.RequestURI, "/v2/", "", 1), "/_trust/tuf", "", 1)
@@ -220,7 +226,6 @@ func autoupdateDetectedChange(t *testing.T, settings *Settings, c *http.Client, 
 	assert.Nil(t, cberr)
 	_, err = os.Stat(path)
 	assert.Nil(t, err)
-
 }
 
 func autoupdateDetectedChangeAfterInterval(t *testing.T, settings *Settings, c *http.Client, stageDir string, k *clock.MockClock) {
@@ -380,6 +385,8 @@ func setupEndToEndTest(t *testing.T, remoteVersion, localVersion int) (*Settings
 }
 
 func TestEndToEnd(t *testing.T) {
+	t.Parallel()
+
 	testTime, _ := time.Parse(time.UnixDate, "Sat Jul 1 18:00:00 CST 2017")
 	mockClock := clock.NewMockClock(testTime)
 	client := testHTTPClient()

--- a/tuf/delegation_test.go
+++ b/tuf/delegation_test.go
@@ -444,6 +444,8 @@ func TestEndToEnd(t *testing.T) {
 		{"interleaved operations", 1, 2, interleavedOperations},
 		{"truncated download", 1, 2, genCorruptDownloadTest(replaceBodyCorruption, errLengthIncorrect)},
 		{"corrupt download", 1, 2, genCorruptDownloadTest(overwriteCorruption, errHashIncorrect)},
+		{"empty download", 1, 2, genCorruptDownloadTest(emptyBodyCorruption, errLengthIncorrect)},
+
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tuf/fim.go
+++ b/tuf/fim.go
@@ -1,0 +1,83 @@
+package tuf
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"hash"
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// FileIntegrityMeta hashes and length of a file based resource to help ensure
+// the binary footprint of the file hasn't been tampered with
+type FileIntegrityMeta struct {
+	Hashes map[hashingMethod]string `json:"hashes"`
+	Length int64                    `json:"length"`
+}
+
+func newFileIntegrityMeta() *FileIntegrityMeta {
+	return &FileIntegrityMeta{
+		Hashes: make(map[hashingMethod]string),
+	}
+}
+
+func (fim FileIntegrityMeta) clone() *FileIntegrityMeta {
+	h := make(map[hashingMethod]string)
+	for k, v := range fim.Hashes {
+		h[k] = v
+	}
+	return &FileIntegrityMeta{h, fim.Length}
+}
+
+// Equal is deep comparison of two FileIntegrityMeta
+func (fim FileIntegrityMeta) Equal(fimTarget FileIntegrityMeta) bool {
+	if fim.Length != fimTarget.Length {
+		return false
+	}
+	if len(fim.Hashes) != len(fimTarget.Hashes) {
+		return false
+	}
+	for algo, hash := range fim.Hashes {
+		h, ok := fimTarget.Hashes[algo]
+		if !ok {
+			return false
+		}
+		if h != hash {
+			return false
+		}
+	}
+	return true
+}
+
+// File hash and length validation per TUF 5.5.2
+func (fim FileIntegrityMeta) verify(rdr io.Reader) error {
+	var hashes []hashInfo
+	for algo, expectedHash := range fim.Hashes {
+		var hashFunc hash.Hash
+		valid, err := base64.StdEncoding.DecodeString(expectedHash)
+		if err != nil {
+			return errors.New("invalid hash in verify")
+		}
+		hashFunc, err = getHasher(algo)
+		if err != nil {
+			return err
+		}
+		rdr = io.TeeReader(rdr, hashFunc)
+		hashes = append(hashes, hashInfo{hashFunc, valid})
+	}
+	length, err := io.Copy(ioutil.Discard, rdr)
+	if err != nil {
+		return err
+	}
+	if length != fim.Length {
+		return errLengthIncorrect
+	}
+	for _, h := range hashes {
+		if subtle.ConstantTimeCompare(h.valid, h.h.Sum(nil)) != 1 {
+			return errHashIncorrect
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds some tests that show correct detection of incorrectly downloaded files. 

It has some light refactoring to fit with my understanding of best practices. 